### PR TITLE
Remove unused parameter in parse-files

### DIFF
--- a/packages/sooho-cli/src/commands/audit.ts
+++ b/packages/sooho-cli/src/commands/audit.ts
@@ -25,7 +25,7 @@ export default class Audit extends Command {
     const stats = await lstat(inputPath)
     const routes = stats.isFile() ? [inputPath] : await powerwalker(inputPath)
     const filePaths = routes.filter(onlySolidity)
-    const parsed = await parseFiles(filePaths, true)
+    const parsed = await parseFiles(filePaths)
     const {errors, success: {functions, constructors}} = parsed
 
     if (errors.length > 0) {

--- a/packages/sooho-cli/src/commands/encrypt.ts
+++ b/packages/sooho-cli/src/commands/encrypt.ts
@@ -26,7 +26,7 @@ export default class Encrypt extends Command {
     const stats = await lstat(inputPath)
     const routes = stats.isFile() ? [inputPath] : await powerwalker(inputPath)
     const filePaths = routes.filter(onlySolidity)
-    const parsed = await parseFiles(filePaths, abstract)
+    const parsed = await parseFiles(filePaths)
     const {errors, success: {functions, constructors}} = parsed
 
     if (errors.length > 0) {

--- a/packages/sooho-cli/src/utils/parse-files.ts
+++ b/packages/sooho-cli/src/utils/parse-files.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import {promisify} from 'util'
 import * as parser from '@sooho/parser'
 
-export async function parseFiles(filePaths, abstract) {
+export async function parseFiles(filePaths) {
   const totalFiles = filePaths.length
   let files = new Array(totalFiles)
   let functions = []


### PR DESCRIPTION
cli fails `prepack` due to irregular function call - `parseFiles` [ref](https://github.com/soohoio/sooho/blob/develop/packages/sooho-cli/src/commands/generate-db.ts#L40)

before PR #21 , `parseFiles` requires two paramters / but after update, it only uses one paramter
Since `abstract` is not used in function `parseFiles`, it should be removed