### PR TITLE
fix(sooho-parser): remove a self reference to ASTBuilder

### DIFF
--- a/packages/sooho-parser/src/ASTBuilder.js
+++ b/packages/sooho-parser/src/ASTBuilder.js
@@ -1113,10 +1113,6 @@ ASTBuilder.prototype._range = function(ctx) {
   return { range: [ctx.start.start, ctx.stop.stop] }
 }
 
-ASTBuilder.prototype._self = function(ctx) {
-  return { self: ctx }
-}
-
 ASTBuilder.prototype.meta = function(ctx) {
   const ret = {}
   if (this.options.loc) {
@@ -1125,7 +1121,6 @@ ASTBuilder.prototype.meta = function(ctx) {
   if (this.options.range) {
     Object.assign(ret, this._range(ctx))
   }
-  Object.assign(ret, this._self(ctx))
   return ret
 }
 


### PR DESCRIPTION
Due to a self-reference, tests have been failed. And I found `_self` is not used for now.